### PR TITLE
Allow bundles in 'Installed' mode before starting to upgrade

### DIFF
--- a/lib/capistrano-karaf/install.rb
+++ b/lib/capistrano-karaf/install.rb
@@ -76,7 +76,7 @@ module Install
 
     wait_for_all_bundles(:timeout => 180, :sleeptime => 10) do |b|
       if b[:level].to_i > args[:startlevel_before_upgrade] 
-        b[:status] == "Resolved"
+        ["Resolved", "Installed"].include? b[:status]
       else
         true
       end


### PR DESCRIPTION
When an upgrade was installed partially, then retrying the deployment fails because the bundles that were already installed are in "INSTALLED" mode (due to the start-level, they don't get in resolved mode).
